### PR TITLE
Plugins for py3

### DIFF
--- a/txi2p/plugins.py
+++ b/txi2p/plugins.py
@@ -5,7 +5,6 @@ from builtins import object
 from twisted.internet.endpoints import clientFromString
 from twisted.internet.interfaces import IStreamClientEndpointStringParserWithReactor
 from twisted.internet.interfaces import IStreamServerEndpointStringParser
-from six import PY3 as _PY3
 from zope.interface import implementer
 
 from txi2p.bob.endpoints import BOBI2PClientEndpoint, BOBI2PServerEndpoint
@@ -15,12 +14,7 @@ from txi2p.sam.endpoints import (
 )
 from txi2p.utils import getApi
 
-if not _PY3:
-    from twisted.plugin import IPlugin
-else:
-    from zope.interface import Interface
-    class IPlugin(Interface):
-        pass
+from twisted.plugin import IPlugin
 
 
 def _parseOptions(options):

--- a/txi2p/test/test_plugins.py
+++ b/txi2p/test/test_plugins.py
@@ -24,8 +24,6 @@ from txi2p.test.util import fakeSession
 
 if twisted.version < Version('twisted', 14, 0, 0):
     skip = 'txi2p.plugins requires twisted 14.0 or newer'
-elif sys.version_info[0] >= 3:
-    skip = 'txi2p.plugins doesn\'t support Python 3 yet'
 else:
     skip = None
 


### PR DESCRIPTION
The "i2p" endpoint description parser plugins are undiscoverable on Python 3 because they are defined using a txi2p-internal `IPlugin` on Python 3 which is not the same as the one from Twisted.

This un-skips the plugin tests on Python 3 and switches to Twisted's `IPlugin`.