### PR TITLE
Avoid trying to iterate over a `None` options values

### DIFF
--- a/txi2p/plugins.py
+++ b/txi2p/plugins.py
@@ -5,7 +5,6 @@ from builtins import object
 from twisted.internet.endpoints import clientFromString
 from twisted.internet.interfaces import IStreamClientEndpointStringParserWithReactor
 from twisted.internet.interfaces import IStreamServerEndpointStringParser
-from six import PY3 as _PY3
 from zope.interface import implementer
 
 from txi2p.bob.endpoints import BOBI2PClientEndpoint, BOBI2PServerEndpoint
@@ -15,12 +14,7 @@ from txi2p.sam.endpoints import (
 )
 from txi2p.utils import getApi
 
-if not _PY3:
-    from twisted.plugin import IPlugin
-else:
-    from zope.interface import Interface
-    class IPlugin(Interface):
-        pass
+from twisted.plugin import IPlugin
 
 
 def _parseOptions(options):

--- a/txi2p/sam/session.py
+++ b/txi2p/sam/session.py
@@ -101,9 +101,11 @@ SessionCreateProtocol = makeSAMProtocol(
 class SessionCreateFactory(SAMFactory):
     protocol = SessionCreateProtocol
 
-    def __init__(self, nickname, style='STREAM', keyfile=None, localPort=None, options={}, sigType=None):
+    def __init__(self, nickname, style='STREAM', keyfile=None, localPort=None, options=None, sigType=None):
         if style != 'STREAM':
             raise error.UnsupportedSocketType()
+        if options is None:
+            options = {}
         self.nickname = nickname
         self.style = style
         self._keyfile = keyfile

--- a/txi2p/sam/session.py
+++ b/txi2p/sam/session.py
@@ -24,7 +24,7 @@ def eprint(*args, **kwargs):
 
 
 class SessionCreateSender(SAMSender):
-    def sendSessionCreate(self, samVersion, style, id, privKey=None, localPort=None, options={}, sigType=None):
+    def sendSessionCreate(self, samVersion, style, id, privKey, localPort, options, sigType):
         msg = 'SESSION CREATE'
         msg += ' STYLE=%s' % style
         msg += ' ID=%s' % id

--- a/txi2p/test/test_plugins.py
+++ b/txi2p/test/test_plugins.py
@@ -24,8 +24,6 @@ from txi2p.test.util import fakeSession
 
 if twisted.version < Version('twisted', 14, 0, 0):
     skip = 'txi2p.plugins requires twisted 14.0 or newer'
-elif sys.version_info[0] >= 3:
-    skip = 'txi2p.plugins doesn\'t support Python 3 yet'
 else:
     skip = None
 


### PR DESCRIPTION
For callers of `SAMI2PStreamClientEndpoint.new` and `SAMI2PStreamServerEndpoint.new` which provided no dict value for `options`, session setup would eventually fail because the default value of `None` for `options` in those methods makes it all the way down to the protocol code which requires "no options" to be represented as an empty dictionary instead of as `None`.

This adds tests for this case of these two methods and makes `SessionCreateFactory` force options to be an empty dict if `None` is given.  It also makes `None` the default in `SessionCreateFactory.__init__` rather than `{}` because mutable values as defaults usually leads to trouble eventually

This is stacked on top of #1
